### PR TITLE
fix: tsoa logs warning

### DIFF
--- a/src/types/auth0/LogsResponse.ts
+++ b/src/types/auth0/LogsResponse.ts
@@ -33,7 +33,9 @@ interface LogCommonFields {
   auth0_client?: {
     name: string;
     version: string;
-    env?: object;
+    env?: {
+      node: string;
+    };
   };
   isMobile?: boolean;
 }


### PR DESCRIPTION
Tsoa didn't like having object as type. This seems to cover the current cases.